### PR TITLE
Seitentitel aus TOC entfernt

### DIFF
--- a/_posts/2000-01-01-055-staatstrojaner.md
+++ b/_posts/2000-01-01-055-staatstrojaner.md
@@ -4,6 +4,10 @@ layout: capter
 permalink: /staatstrojaner/
 category: capter
 ---
+
+# Online Durchsuchung und Quellen TKÜ
+{: .no_toc }
+
 <details markdown="block">
   <summary>
     Inhalt

--- a/_posts/2000-01-01-090-email.md
+++ b/_posts/2000-01-01-090-email.md
@@ -5,6 +5,7 @@ permalink: /mail-verschluesselung/
 category: capter
 ---
 # Mail-Verschlüsselung
+{: .no_toc }
 
 <details markdown="block">
   <summary>

--- a/_posts/2000-01-01-110-messenger.md
+++ b/_posts/2000-01-01-110-messenger.md
@@ -5,6 +5,7 @@ permalink: /messenger/
 category: capter
 ---
 # Messenger
+{: .no_toc }
 
 <details markdown="block">
   <summary>

--- a/_posts/2000-01-01-190-anonym-im-netz.md
+++ b/_posts/2000-01-01-190-anonym-im-netz.md
@@ -5,6 +5,7 @@ permalink: /anonym-im-netz/
 category: capter
 ---
 # Anonym im Netz
+{: .no_toc }
 
 <details markdown="block">
   <summary>


### PR DESCRIPTION
Die Seitentitel können mit 
```
# Titel
{: .no_toc }
```
Markiert werden um aus dem TOC ausgeschlossen zu werden.