### PR TITLE
chore: Extend site description for meta tags

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@ title: beschlagnahmt.org
 author:
   name: ACAB
   email: beschlagnahmt@riseup.net
-description: IT-Sicherheit für Aktivisti
+description: IT-Sicherheit für Aktivisti! Behörden können deine elektronischen Geräte beschlagnahmen, auslesen oder deine Kommunikation überwachen. Du kannst dafür sorgen, dass die ganze Aktion zwar nervig ist, aber der Staat nicht in deinen persönlichen Daten rumschnüffelt.
 
 minima:
   date_format: "%d.%m.%Y"


### PR DESCRIPTION
Ich hab den Wert für `description` in der Config erweitert. Der Textauszug stammt aus der ``about.md``.